### PR TITLE
Advertisement messages publication to MQTT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ additional topics to help book-keeping:
   connected to the peripheral, e.g. `BLE2MQTT-XXXX`, where `XXXX` are the last 2
   octets of the ESP32's WiFi MAC address
 
+## Advertisement
+
+This application supports publishing all BLE advertisements over MQTT,
+When the advertisement section is set inside ble section.
+The push interval is the seconds between mqtt publications of advertisement messages.
+
+* 0 means every message can be send
+* -1 no message at all can be send
+* other values the seconds between advertisements pusblished to mqtt.
+
+```json
+{
+  "ble": {
+    "advertisement" : {
+      "publishinterval": 5
+    }
+}
+```
+
+The message itself the hexadecimal string value of message.
+
 ## Beacons
 
 This application supports publishing BLE beacon advertisements over MQTT.

--- a/main/ble.h
+++ b/main/ble.h
@@ -30,6 +30,8 @@ typedef void (*ble_on_device_characteristic_value_cb_t)(mac_addr_t mac,
     ble_uuid_t service, ble_uuid_t characteristic, uint8_t *value,
     size_t value_len);
 typedef uint32_t (*ble_on_passkey_requested_cb_t)(mac_addr_t mac);
+typedef void (*ble_set_on_device_advertisement_cb_t)(mac_addr_t mac, uint8_t *adv_data,
+    size_t adv_data_len, int rssi);
 
 /* Event handlers */
 void ble_set_on_beacon_discovered_cb(ble_on_beacon_discovered_cb_t cb);
@@ -41,6 +43,7 @@ void ble_set_on_device_services_discovered_cb(
 void ble_set_on_device_characteristic_value_cb(
     ble_on_device_characteristic_value_cb_t cb);
 void ble_set_on_passkey_requested_cb(ble_on_passkey_requested_cb_t cb);
+void ble_set_on_device_advertisement_cb(ble_set_on_device_advertisement_cb_t cb);
 
 /* BLE Operations */
 void ble_clear_bonding_info(void);
@@ -53,6 +56,8 @@ int ble_disconnect(mac_addr_t mac);
 int ble_disconnect_all(void);
 
 int ble_services_scan(mac_addr_t mac);
+int ble_advertisement_process_required(mac_addr_t mac, int interval_sec);
+
 int ble_foreach_characteristic(mac_addr_t mac,
     ble_on_device_characteristic_found_cb_t cb);
 

--- a/main/ble_utils.c
+++ b/main/ble_utils.c
@@ -230,6 +230,22 @@ static characteristic_type_t *ble_get_characteristic_types(ble_uuid_t uuid)
     return ret;
 }
 
+
+char *chartohex(const uint8_t *data, size_t len)
+{
+	static char buf[1024];
+	char *p = buf;
+	int i = 0;
+
+	for (; i < len; i++) {
+		p += sprintf(p, "%02hhX", data[i]);
+	}
+
+	*(p) = '\0';
+    return buf;
+
+}
+
 char *chartoa(ble_uuid_t uuid, const uint8_t *data, size_t len)
 {
     characteristic_type_t *types = ble_get_characteristic_types(uuid);
@@ -416,6 +432,7 @@ char *chartoa(ble_uuid_t uuid, const uint8_t *data, size_t len)
     *(p - 1) = '\0';
     return buf;
 }
+
 
 uint8_t *atochar(ble_uuid_t uuid, const char *data, size_t len, size_t *ret_len)
 {

--- a/main/ble_utils.h
+++ b/main/ble_utils.h
@@ -29,6 +29,7 @@ typedef struct ble_device_t {
     uint16_t conn_id;
     ble_service_t *services;
     uint8_t is_authenticating;
+    time_t last_processed_adv_time;
 } ble_device_t;
 
 /* Callback functions */
@@ -43,6 +44,7 @@ char *mactoa(mac_addr_t mac);
 int atomac(const char *str, mac_addr_t mac);
 char *uuidtoa(ble_uuid_t uuid);
 int atouuid(const char *str, ble_uuid_t uuid);
+char *chartohex(const uint8_t *data, size_t len);
 char *chartoa(ble_uuid_t uuid, const uint8_t *data, size_t len);
 uint8_t *atochar(ble_uuid_t uuid, const char *data, size_t len,
     size_t *ret_len);

--- a/main/config.c
+++ b/main/config.c
@@ -146,6 +146,18 @@ uint32_t config_ble_passkey_get(const char *mac)
     return 0;
 }
 
+uint32_t config_ble_publish_advertisement_interval(void)
+{
+    cJSON *ble = cJSON_GetObjectItemCaseSensitive(config, "ble");
+    cJSON *advertisement = cJSON_GetObjectItemCaseSensitive(ble, "advertisement");
+    cJSON *interval = cJSON_GetObjectItemCaseSensitive(advertisement, "publishinterval");
+
+    if (cJSON_IsNumber(interval))
+        return interval->valuedouble;
+
+    return -1;
+}
+
 /* MQTT Configuration*/
 const char *config_mqtt_server_get(const char *param_name)
 {

--- a/main/config.h
+++ b/main/config.h
@@ -15,6 +15,7 @@ uint8_t config_ble_characteristic_should_include(const char *uuid);
 uint8_t config_ble_service_should_include(const char *uuid);
 uint8_t config_ble_should_connect(const char *mac);
 uint32_t config_ble_passkey_get(const char *mac);
+uint32_t config_ble_publish_advertisement_interval(void);
 
 /* MQTT Configuration*/
 const char *config_mqtt_host_get(void);


### PR DESCRIPTION
I have Xiaomi Mijjia Temperature / Humadity sensor devices which are not using beacon protocols, it uses the plain advertisement messages with extended custom data messages which contain sensor data too. The current version of software was not able to handle the delegation of advertismenet messages, because if device was discovered never was republished. 