### PR TITLE
Added support to Beewi Smart Door as broadcaster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ is published.
   * `TLM` frames: `Voltage`, `Temperature`, `Count` and `Uptime`
 * For MiJia temperature and humidity sensors: `MACAddress`, `MessageCounter`,
   `Temperature`, `Humidity` and `BatteryLevel`
-
+* For BeeWi Smart Door sensors: `Status` (opening door state) and `Battery`
+  
 **Note:** Broadcaster topics are published without the retained flag regardless
 of what's defined in the configuration file.
 

--- a/main/broadcasters.c
+++ b/main/broadcasters.c
@@ -408,14 +408,7 @@ typedef struct {
 static beewi_smart_door_t *beewi_smart_door_data_get(uint8_t *adv_data, 
     uint8_t adv_data_len, uint8_t *beewi_smart_door_len)
 {
-    
-    uint8_t name_len;
     uint8_t len;
-    char *name = (char *)esp_ble_resolve_adv_data(adv_data, 
-        ESP_BLE_AD_TYPE_NAME_CMPL, &name_len);
-    if (strncmp(name, "BeeWi Smart Door", name_len) != 0)
-        return NULL;
-       
     uint8_t *data = esp_ble_resolve_adv_data(adv_data,
         ESP_BLE_AD_MANUFACTURER_SPECIFIC_TYPE, &len);
         
@@ -428,10 +421,14 @@ static beewi_smart_door_t *beewi_smart_door_data_get(uint8_t *adv_data,
 static int beewi_smart_door_is_broadcaster(uint8_t *adv_data, 
     size_t adv_data_len)
 {
-    uint8_t len;
-    //char dev_name[16]; 
-    //uint8_t dev_len = (uint8_t)sizeof(dev_name);
+    uint8_t name_len;
+    char *name = (char *)esp_ble_resolve_adv_data(adv_data, 
+        ESP_BLE_AD_TYPE_NAME_CMPL, &name_len);
+    if (strncmp(name, "BeeWi Smart Door", name_len) != 0)
+        return 0
+    ;
     
+    uint8_t len;
     beewi_smart_door_t *beewi_smart_door = beewi_smart_door_data_get(adv_data,
     adv_data_len, &len);
     

--- a/main/broadcasters.h
+++ b/main/broadcasters.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define MAX_BROADCASTER_NAME 16
+#define MAX_BROADCASTER_NAME 17
 
 /* Event callback types */
 typedef void (*broadcaster_meta_data_cb_t)(char *name, char *val, void *ctx);


### PR DESCRIPTION
Works well. 

It needs to blacklist the Beewi mac in the "services:" config first or ble2mqtt will connect to it and enable notifications. ( there are but they are useless ) 

Interesting data are broadcasted in the advertising payload, not served as service characteristics.
Device will be locked if connected on it and won't broadcast anything.

Also strange bug in the published mqtt side, the  Type field displays : 

```
Beewi Smart Door�]
@�]
@Mijia Temp+Hum
```
Looks like an overflow. I haven't found yet where is the fonction that displays this Type field.

