### PR TITLE
Add Olimex ESP32-POE board support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ The `eth` section below includes the following entries:
 ```json
 {
   "eth": {
-    "phy": "MY_ETH_PHY"
+    "phy": "MY_ETH_PHY",
+    "phy_power_pin": -1
   }
 }
 ```
@@ -130,6 +131,7 @@ The `eth` section below includes the following entries:
   * `RTL8201`
   * `LAN8720`
   * `DP83848`
+* `phy_power_pin` - Some ESP32 Ethernet modules such as the Olimex ESP32-POE require a GPIO pin to be set high in order to enable the PHY. Omitting this configuration or setting it to -1 will disable this.
 
 _Note: Defining the `eth` section will disable WiFi_
 
@@ -299,3 +301,21 @@ image it's based on the git tag and for the configuration file it's an MD5 hash
 of its contents. In order to force an upgrade regardless of the currently
 installed version, run `idf.py force-upload` or `idf.py force-upload-config`
 respectively.
+
+## Board Compatibility
+The `sdkconfig.defaults` included in this project covers common configurations.
+
+### Olimex ESP32-POE
+A number of minor changes are required to support this board:
+* Set the `eth` section as follows:
+  ```
+  {
+    "eth": {
+      "phy": "LAN8720",
+      "phy_power_pin": 12
+    }
+  }
+  ```
+* Run `idf.py menuconfig` and modify the Ethernet configuration to:
+  * RMII_CLK_OUTPUT=y
+  * RMII_CLK_OUT_GPIO=17

--- a/main/ble2mqtt.c
+++ b/main/ble2mqtt.c
@@ -20,6 +20,7 @@
 #include <freertos/task.h>
 #include <freertos/timers.h>
 #include <string.h>
+#include <driver/gpio.h>
 
 #define MAX_TOPIC_LEN 256
 static const char *TAG = "BLE2MQTT";
@@ -847,6 +848,12 @@ void app_main()
     switch (config_network_type_get())
     {
     case NETWORK_TYPE_ETH:
+        if (config_eth_phy_power_pin_get() >= 0) {
+            gpio_pad_select_gpio(config_eth_phy_power_pin_get());
+            gpio_set_direction(config_eth_phy_power_pin_get(), GPIO_MODE_OUTPUT);
+            gpio_set_level(config_eth_phy_power_pin_get(), 1);
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
         eth_connect(eth_phy_atophy(config_eth_phy_get()));
         break;
     case NETWORK_TYPE_WIFI:

--- a/main/ble2mqtt.c
+++ b/main/ble2mqtt.c
@@ -848,13 +848,7 @@ void app_main()
     switch (config_network_type_get())
     {
     case NETWORK_TYPE_ETH:
-        if (config_eth_phy_power_pin_get() >= 0) {
-            gpio_pad_select_gpio(config_eth_phy_power_pin_get());
-            gpio_set_direction(config_eth_phy_power_pin_get(), GPIO_MODE_OUTPUT);
-            gpio_set_level(config_eth_phy_power_pin_get(), 1);
-            vTaskDelay(pdMS_TO_TICKS(10));
-        }
-        eth_connect(eth_phy_atophy(config_eth_phy_get()));
+        eth_connect(eth_phy_atophy(config_eth_phy_get()), config_eth_phy_power_pin_get());
         break;
     case NETWORK_TYPE_WIFI:
         /* Start by connecting to network */

--- a/main/ble2mqtt.c
+++ b/main/ble2mqtt.c
@@ -20,7 +20,6 @@
 #include <freertos/task.h>
 #include <freertos/timers.h>
 #include <string.h>
-#include <driver/gpio.h>
 
 #define MAX_TOPIC_LEN 256
 static const char *TAG = "BLE2MQTT";

--- a/main/config.c
+++ b/main/config.c
@@ -217,15 +217,16 @@ const char *config_eth_phy_get(void)
     return NULL;
 }
 
-int8_t *config_eth_phy_power_pin_get(void)
+int8_t config_eth_phy_power_pin_get(void)
 {
     cJSON *eth = cJSON_GetObjectItemCaseSensitive(config, "eth");
-    cJSON *phy_power_pin = cJSON_GetObjectItemCaseSensitive(eth, "phy_power_pin");
+    cJSON *phy_power_pin = cJSON_GetObjectItemCaseSensitive(eth,
+        "phy_power_pin");
 
     if (cJSON_IsNumber(phy_power_pin))
-        return (int8_t) phy_power_pin->valuedouble;
+        return phy_power_pin->valuedouble;
 
-    return (int8_t) -1;
+    return -1;
 }
 
 /* MQTT Configuration*/

--- a/main/config.c
+++ b/main/config.c
@@ -217,6 +217,17 @@ const char *config_eth_phy_get(void)
     return NULL;
 }
 
+int8_t *config_eth_phy_power_pin_get(void)
+{
+    cJSON *eth = cJSON_GetObjectItemCaseSensitive(config, "eth");
+    cJSON *phy_power_pin = cJSON_GetObjectItemCaseSensitive(eth, "phy_power_pin");
+
+    if (cJSON_IsNumber(phy_power_pin))
+        return (int8_t) phy_power_pin->valuedouble;
+
+    return (int8_t) -1;
+}
+
 /* MQTT Configuration*/
 const char *config_mqtt_server_get(const char *param_name)
 {

--- a/main/config.h
+++ b/main/config.h
@@ -22,7 +22,7 @@ uint32_t config_ble_passkey_get(const char *mac);
 
 /* Ethernet Configuration */
 const char *config_eth_phy_get(void);
-int8_t *config_eth_phy_power_pin_get(void);
+int8_t config_eth_phy_power_pin_get(void);
 
 /* MQTT Configuration*/
 const char *config_mqtt_host_get(void);

--- a/main/config.h
+++ b/main/config.h
@@ -22,6 +22,7 @@ uint32_t config_ble_passkey_get(const char *mac);
 
 /* Ethernet Configuration */
 const char *config_eth_phy_get(void);
+int8_t *config_eth_phy_power_pin_get(void);
 
 /* MQTT Configuration*/
 const char *config_mqtt_host_get(void);

--- a/main/eth.c
+++ b/main/eth.c
@@ -104,7 +104,7 @@ eth_phy_t eth_phy_atophy(const char *phy)
     return p->phy;
 }
 
-int eth_connect(eth_phy_t eth_phy)
+int eth_connect(eth_phy_t eth_phy, int8_t eth_phy_power_pin)
 {
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
@@ -115,6 +115,13 @@ int eth_connect(eth_phy_t eth_phy)
     esp_eth_handle_t eth_handle = NULL;
 
     ESP_ERROR_CHECK(esp_eth_set_default_handlers(eth_netif));
+
+    if (eth_phy_power_pin >= 0) {
+        gpio_pad_select_gpio(eth_phy_power_pin);
+        gpio_set_direction(eth_phy_power_pin, GPIO_MODE_OUTPUT);
+        gpio_set_level(eth_phy_power_pin, 1);
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
 
     switch (eth_phy)
     {

--- a/main/eth.h
+++ b/main/eth.h
@@ -22,7 +22,7 @@ void eth_set_on_connected_cb(eth_on_connected_cb_t cb);
 void eth_set_on_disconnected_cb(eth_on_disconnected_cb_t cb);
 
 int eth_initialize(void);
-int eth_connect(eth_phy_t eth_phy);
+int eth_connect(eth_phy_t eth_phy, int8_t eth_phy_power_pin);
 uint8_t *eth_mac_get(void);
 void eth_hostname_set(const char *hostname);
 


### PR DESCRIPTION
This request adds support for the Olimex ESP32-POE board, which requires a GPIO pin toggled to enable the interface pin. This GPIO pin has been added as a JSON configuration parameter. The readme has also been updated with instructions for running on this particular board.