### PR TITLE
Expand Xiaomi Mijia MiBeacon support to e.g. MiFlora, Formaldehyde sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ is published.
   * `UID` frames: `Namespace`, `Instance` and `Distance`
   * `URL` frames: `URL` and `Distance`
   * `TLM` frames: `Voltage`, `Temperature`, `Count` and `Uptime`
-* For MiJia temperature and humidity sensors: `MACAddress`, `MessageCounter`,
-  `Temperature`, `Humidity` and `BatteryLevel`
+* For Xiaomi Mijia (MiBeacon) sensors: `MACAddress`, `MessageCounter`,
+  `Temperature`, `Humidity`, `Moisture`, `Formaldehyde`, `Illuminance`,
+  `Conductivity`, `Switch`, `Consumable`, `BatteryLevel`
 * For BeeWi Smart Door sensors: `Status` and `Battery`
-* For Xiomi LYWSD03MMC Temperature Sensors running the ATC1441 firmware:
+* For Xiaomi LYWSD03MMC Temperature Sensors running the ATC1441 firmware:
   `MACAddress`, `MessageCounter`, `Temperature`, `Humidity`, `BatteryLevel` 
   and `BatteryVolts` (_See https://github.com/atc1441/ATC_MiThermometer_)
 


### PR DESCRIPTION
- rename `temp_hum` to `sensor` 
- add support for skipping the capability byte that's in between the MAC and the data on some devices (e.g. MiFlora/VegTrug plant sensors)
- add more data types
- add support for multiple data items in one payload (not really tested as none of my devices seem to do this)

Roughly based on the best "documentation" for the protocol that is https://github.com/custom-components/ble_monitor.