### PR TITLE
added HEX string type and option to disable auto-subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ configuration:
   http://www.bluetooth.org. Each characteristic can include a `name` field which
   will be used in the MQTT topic instead of its UUID and a `types` array
   defining how to parse the byte array reflecting the characteristic's value.
+  The `subscribe` attribute can be set to "false" if you don't want to automatically 
+  subscribe for Notifications and Indications on a Characteristic.
   In addition, it's possible to define a white/black list for discovered
   characteristics. The white/black list UUIDs may contain the wildcard character
   `?` to denote any value for a nibble. For example:
@@ -265,6 +267,7 @@ configuration:
       "definitions": {
         "00002f01-0000-1000-8000-00805f9b34fb": {
           "name": "Relay State",
+          "subscribe": true,
           "types": [
             "boolean"
           ]

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(file ${www_files})
     get_filename_component(www_file_dir ${build_dir}/www/${file}.gz DIRECTORY)
     file(MAKE_DIRECTORY ${www_file_dir})
     add_custom_command(OUTPUT ${build_dir}/www/${file}.gz
-        COMMAND tar -czf ${build_dir}/www/${file}.gz ${PROJECT_DIR}/www/${file}
+        COMMAND gzip -c ${PROJECT_DIR}/www/${file} > ${build_dir}/www/${file}.gz
         DEPENDS ${PROJECT_DIR}/www/${file})
     target_add_binary_data(${COMPONENT_LIB} ${build_dir}/www/${file}.gz
         BINARY RENAME_TO ${c_name})

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(file ${www_files})
     get_filename_component(www_file_dir ${build_dir}/www/${file}.gz DIRECTORY)
     file(MAKE_DIRECTORY ${www_file_dir})
     add_custom_command(OUTPUT ${build_dir}/www/${file}.gz
-        COMMAND gzip -c ${PROJECT_DIR}/www/${file} > ${build_dir}/www/${file}.gz
+        COMMAND tar -czf ${build_dir}/www/${file}.gz ${PROJECT_DIR}/www/${file}
         DEPENDS ${PROJECT_DIR}/www/${file})
     target_add_binary_data(${COMPONENT_LIB} ${build_dir}/www/${file}.gz
         BINARY RENAME_TO ${c_name})

--- a/main/ble2mqtt.c
+++ b/main/ble2mqtt.c
@@ -458,8 +458,13 @@ static void ble_on_characteristic_found(mac_addr_t mac, ble_uuid_t service_uuid,
     /* Characteristic can notify / indicate on changes */
     if (properties & (CHAR_PROP_NOTIFY | CHAR_PROP_INDICATE))
     {
-        ble_characteristic_notify_register(mac, service_uuid,
-            characteristic_uuid);
+        if (config_ble_characteristic_should_subscribe(uuidtoa(characteristic_uuid)))
+        {
+            ESP_LOGI(TAG, "Register Notify characteristic: " UUID_FMT ".",
+                UUID_PARAM(characteristic_uuid));
+            ble_characteristic_notify_register(mac, service_uuid,
+                characteristic_uuid);
+        }
     }
 }
 

--- a/main/ble_utils.c
+++ b/main/ble_utils.c
@@ -195,6 +195,7 @@ static characteristic_type_t ble_atotype(const char *type)
         { "reg-cert-data-list", CHAR_TYPE_REG_CERT_DATA_LIST },
         { "variable", CHAR_TYPE_VARIABLE },
         { "gatt-uuid", CHAR_TYPE_GATT_UUID },
+        { "hex", CHAR_TYPE_HEX },
         { NULL, CHAR_TYPE_UNKNOWN },
     };
 
@@ -241,6 +242,7 @@ static size_t ble_type_size(characteristic_type_t type)
     case CHAR_TYPE_UINT16:
     case CHAR_TYPE_SINT16:
     case CHAR_TYPE_SFLOAT:
+    case CHAR_TYPE_HEX:
         return 2;
     case CHAR_TYPE_24BIT:
     case CHAR_TYPE_UINT24:
@@ -293,6 +295,9 @@ char *chartoa(ble_uuid_t uuid, const uint8_t *data, size_t len)
 
         switch (*types)
         {
+        case CHAR_TYPE_HEX:
+            p += sprintf(p, "%2hhx,", data[i]); 
+            break;
         case CHAR_TYPE_BOOLEAN:
             p += sprintf(p, "%s,", data[i] & 0x01 ? "true" : "false");
             break;
@@ -462,6 +467,10 @@ uint8_t *atochar(ble_uuid_t uuid, const char *data, size_t len, size_t *ret_len)
     {
         switch (*types)
         {
+        case CHAR_TYPE_HEX:
+            sscanf(val, "%2hhx", p);
+            p += 1;
+            break;
         case CHAR_TYPE_BOOLEAN:
             *p = !strcmp(val, "true") ? 1 : 0;
             p += 1;

--- a/main/config.c
+++ b/main/config.c
@@ -173,6 +173,22 @@ uint8_t config_ble_characteristic_should_include(const char *uuid)
     return json_is_in_lists(characteristics, uuid);
 }
 
+uint8_t config_ble_characteristic_should_subscribe(const char *uuid) 
+{
+    cJSON *subscribe = config_ble_get_name_by_uuid(0, uuid, "subscribe");
+
+    /* Not defined, to subscribe is default */
+    if (cJSON_IsTrue(subscribe))
+    {
+        return true;
+    }
+    else if (cJSON_IsFalse(subscribe))
+    {
+        return false;
+    }
+    return true;
+}
+
 uint8_t config_ble_service_should_include(const char *uuid)
 {
     cJSON *ble = cJSON_GetObjectItemCaseSensitive(config, "ble");

--- a/main/config.h
+++ b/main/config.h
@@ -16,6 +16,7 @@ const char *config_ble_service_name_get(const char *uuid);
 const char *config_ble_characteristic_name_get(const char *uuid);
 const char **config_ble_characteristic_types_get(const char *uuid);
 uint8_t config_ble_characteristic_should_include(const char *uuid);
+uint8_t config_ble_characteristic_should_subscribe(const char *uuid);
 uint8_t config_ble_service_should_include(const char *uuid);
 uint8_t config_ble_should_connect(const char *mac);
 uint32_t config_ble_passkey_get(const char *mac);

--- a/main/gatt.h
+++ b/main/gatt.h
@@ -31,7 +31,8 @@ typedef enum {
     CHAR_TYPE_UINT48,
     CHAR_TYPE_UINT8,
     CHAR_TYPE_UTF8S,
-    CHAR_TYPE_VARIABLE
+    CHAR_TYPE_VARIABLE,
+    CHAR_TYPE_HEX
 } characteristic_type_t;
 
 typedef struct {


### PR DESCRIPTION
This adds an option to the config that disables the automatic notification subscription.
It also introduces an "Hex-String" type, in case you don't want to sent integer representations. 