### PR TITLE
fix for idf 5.2.1

### DIFF
--- a/main/mqtt.c
+++ b/main/mqtt.c
@@ -162,7 +162,7 @@ int mqtt_subscribe(const char *topic, int qos, mqtt_on_message_received_cb_t cb,
         return -1;
 
     ESP_LOGD(TAG, "Subscribing to %s", topic);
-    if (esp_mqtt_client_subscribe(mqtt_handle, topic, qos) < 0)
+    if (esp_mqtt_client_subscribe_single(mqtt_handle, topic, qos) < 0)
     {
         ESP_LOGE(TAG, "Failed subscribing to %s", topic);
         return -1;


### PR DESCRIPTION
not sure this is the proper way, but works for me:

    /Users/mah/Ballon/src/BalloonWare/esp32-ble2mqtt/main/mqtt.c: In function 'mqtt_subscribe':
    /Users/mah/esp/v5.2.1-git/components/mqtt/esp-mqtt/include/mqtt_client.h:464:84: error: '_Generic' selector of type 'const char *' is not compatible with any association
      464 | #define esp_mqtt_client_subscribe(client_handle, topic_type, qos_or_size) _Generic((topic_type), \
          |                                                                                    ^
    /Users/mah/Ballon/src/BalloonWare/esp32-ble2mqtt/main/mqtt.c:165:9: note: in expansion of macro 'esp_mqtt_client_subscribe'
      165 |     if (esp_mqtt_client_subscribe(mqtt_handle, topic, qos) < 0)
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~