### PR TITLE
Add PVVX broadcaster

### DIFF
--- a/main/broadcasters.c
+++ b/main/broadcasters.c
@@ -769,7 +769,6 @@ static broadcaster_ops_t atc1441_temp_hum_ops = {
 #define PVVX_TEMP_HUM_SERVICE_UUID 0x181A
 
 typedef struct {
-//    uint16_t not_used;
     uint16_t service_uuid;
     mac_addr_t mac;
     int16_t temp;


### PR DESCRIPTION
This pull request adds the broadcaster support for the PVVX firmware of Xiaomi devices.

PVVX is a fork of the ATC firmware, which supplies more detailed information in the broadcasts without needing to connect to the device.